### PR TITLE
Added parameter to downloads in different languages

### DIFF
--- a/pyheadspace/__main__.py
+++ b/pyheadspace/__main__.py
@@ -31,6 +31,7 @@ EVERYDAY_URL = (
     "https://api.prod.headspace.com/content/view-models/everyday-headspace-banner"
 )
 GROUP_COLLECTION = "https://api.prod.headspace.com/content/group-collections"
+DESIRED_LANGUAGE = os.getenv('DESIRED_LANGUAGE', 'en-US')
 
 if not os.path.exists(BEARER):
     with open(BEARER, "w") as file:
@@ -54,7 +55,7 @@ headers = {
     "accept": "application/vnd.api+json",
     "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36",
     "authorization": BEARER_ID,
-    "hs-languagepreference": "en-US",
+    "hs-languagepreference": DESIRED_LANGUAGE,
     "sec-gpc": "1",
     "origin": "https://my.headspace.com",
     "sec-fetch-site": "same-site",

--- a/pyheadspace/__main__.py
+++ b/pyheadspace/__main__.py
@@ -31,7 +31,7 @@ EVERYDAY_URL = (
     "https://api.prod.headspace.com/content/view-models/everyday-headspace-banner"
 )
 GROUP_COLLECTION = "https://api.prod.headspace.com/content/group-collections"
-DESIRED_LANGUAGE = os.getenv('DESIRED_LANGUAGE', 'en-US')
+DESIRED_LANGUAGE = os.getenv('HEADSPACE_LANG', 'en-US')
 
 if not os.path.exists(BEARER):
     with open(BEARER, "w") as file:


### PR DESCRIPTION
I've added a way to be able to download packs from other languages than the default one _en-US_.
Simply set an environment variable named **DESIRED_LANGUAGE** before running the `headspace` command like this:

### Bash
```bash
export DESIRED_LANGUAGE=fr-FR
headspace pack https://my.headspace.com/modes/meditate/content/123 -d 15
```

### PowerShell
```powershell
$env:DESIRED_LANGUAGE='fr-FR'
headspace pack https://my.headspace.com/modes/meditate/content/123 -d 15
```

```text
Pack metadata: 
Name:  La patience
Description:  Apprenez à reconnaître l’impatience, à la gérer et à lâcher prise.
Downloading Séance 1
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 2
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 3
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 4
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 5
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 6
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 7
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 8
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 9
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Séance 10
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Body Scan
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Downloading Noting
Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
```

This should work for any language supported by Headspace, though I just tested French.